### PR TITLE
Consider publishing to npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,4 +1,13 @@
 {
+  "name": "lato-font",
+  "version": "2.0.10",
+  "description": "Lato font",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/betsol/lato-font.git"
+  },
+  "license": "OFL-1.1",
+  "homepage": "http://www.latofonts.com/",
   "devDependencies": {
     "change-case": "~2",
     "del": "~1",


### PR DESCRIPTION
**npm** allows to install from a github repository, so it's not a huge deal, but it would be nice if you'd publish it to the repository. (I can publish it myself, but since you're already maintaining the **bower** package, you might want to maintain the **npm** package too :smiley:  )

Cheers
